### PR TITLE
Make N configurable via JSON

### DIFF
--- a/services/datamanager/builtin/file_deletion.go
+++ b/services/datamanager/builtin/file_deletion.go
@@ -20,7 +20,7 @@ import (
 var (
 	fsThresholdToTriggerDeletion = .90
 	captureDirToFSUsageRatio     = .5
-	deleteEveryNth               = 5
+	defaultDeleteEveryNth        = 5
 )
 
 var errAtSizeThreshold = errors.New("capture dir is at correct size")
@@ -84,9 +84,11 @@ func exceedsDeletionThreshold(ctx context.Context, captureDirPath string, fsSize
 	return false, nil
 }
 
-func deleteFiles(ctx context.Context, syncer datasync.Manager, captureDirPath string, logger logging.Logger) (int, error) {
+func deleteFiles(ctx context.Context, syncer datasync.Manager, deleteEveryNth int,
+	captureDirPath string, logger logging.Logger) (int, error) {
 	index := 0
 	deletedFileCount := 0
+	logger.Infof("Deleting every nth %d", deleteEveryNth)
 	fileDeletion := func(path string, d fs.DirEntry, err error) error {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/services/datamanager/builtin/file_deletion_test.go
+++ b/services/datamanager/builtin/file_deletion_test.go
@@ -102,26 +102,26 @@ func TestFileDeletion(t *testing.T) {
 	}{
 		{
 			name:                    "if sync disabled, file deleter should delete every 4th file",
-			fileList:                []string{"shouldDelete0.capture", "1.capture", "2.capture", "3.capture", "shouldDelete4.capture"},
-			expectedDeleteFilenames: []string{"shouldDelete0.capture", "shouldDelete4.capture"},
+			fileList:                []string{"shouldDelete0.capture", "1.capture", "2.capture", "3.capture", "4.capture", "shouldDelete5.capture"},
+			expectedDeleteFilenames: []string{"shouldDelete0.capture", "shouldDelete5.capture"},
 		},
 		{
 			name:                    "if sync enabled and all files marked as in progress, file deleter should not delete any files",
 			syncEnabled:             true,
-			fileList:                []string{"0.capture", "1.capture", "2.capture", "3.capture", "4.capture"},
-			syncerInProgressFiles:   []string{"0.capture", "1.capture", "2.capture", "3.capture", "4.capture"},
+			fileList:                []string{"0.capture", "1.capture", "2.capture", "3.capture", "4.capture", "5.capture"},
+			syncerInProgressFiles:   []string{"0.capture", "1.capture", "2.capture", "3.capture", "4.capture", "5.capture"},
 			expectedDeleteFilenames: []string{},
 		},
 		{
 			name:                    "if sync enabled and some files marked as inprogress, file deleter should delete less files",
 			syncEnabled:             true,
-			fileList:                []string{"0.capture", "1.capture", "shouldDelete2.capture", "3.capture", "4.capture"},
+			fileList:                []string{"0.capture", "1.capture", "shouldDelete2.capture", "3.capture", "4.capture", "5.capture"},
 			syncerInProgressFiles:   []string{"0.capture", "1.capture"},
 			expectedDeleteFilenames: []string{"shouldDelete2.capture"},
 		},
 		{
 			name:                    "if sync disabled and files are still being written to, file deleter should not delete any files",
-			fileList:                []string{"0.prog", "1.prog", "2.prog", "3.prog", "4.prog"},
+			fileList:                []string{"0.prog", "1.prog", "2.prog", "3.prog", "4.prog", "5.prog"},
 			expectedDeleteFilenames: []string{},
 		},
 		{
@@ -158,7 +158,7 @@ func TestFileDeletion(t *testing.T) {
 			if tc.shouldCancelContext {
 				cancelFunc()
 			}
-			deletedFileCount, err := deleteFiles(ctx, syncer, tempCaptureDir, logger)
+			deletedFileCount, err := deleteFiles(ctx, syncer, defaultDeleteEveryNth, tempCaptureDir, logger)
 			if tc.shouldCancelContext {
 				test.That(t, err, test.ShouldBeError, context.Canceled)
 			} else {
@@ -202,7 +202,8 @@ func TestFilePolling(t *testing.T) {
 	// flush and close collectors to ensure we have exactly 4 files
 	flusher.flushCollectors()
 	flusher.closeCollectors()
-
+	// number of capture files is based on the number of unique
+	// collectors in the robot config used in this test
 	waitForCaptureFilesToExceedNFiles(tempDir, 4)
 
 	files := getAllFileInfos(tempDir)


### PR DESCRIPTION
Hey yall, this PR is to make the value of N for file deletion configurable via raw JSON. If no value is set, N is the default value of 5, otherwise it's what in the config.
Example service config:
```json
{
      "name": "data_manager-1",
      "namespace": "rdk",
      "type": "data_manager",
      "attributes": {
        "sync_disabled": false,
        "delete_every_nth": 5,
        "sync_interval_mins": 60,
        "capture_dir": "",
        "tags": [],
        "additional_sync_paths": []
      }
}
```
I've tested this works on a pi 
<img width="1110" alt="Screenshot 2024-05-08 at 11 40 01 AM" src="https://github.com/vijayvuyyuru/rdk/assets/13922806/0bace64f-1285-44c0-b15b-8dcdca0e932c">
I can see logs matching when I change the value for N. I also checked there are not random reconfigures happening as a result of this addition. 